### PR TITLE
CompatiblePSEditions

### DIFF
--- a/module/dotenv/dotenv.psd1
+++ b/module/dotenv/dotenv.psd1
@@ -15,7 +15,7 @@
     ModuleVersion     = '0.4.0'
 
     # Supported PSEditions
-    # CompatiblePSEditions = @()
+    CompatiblePSEditions = @('Desktop', 'Core')
 
     # ID used to uniquely identify this module
     GUID              = '13477ff4-551b-48e8-895a-c03e6f826749'
@@ -31,8 +31,6 @@
 
     # Description of the functionality provided by this module
     Description       = 'Allows PowerShell to load Environment Variables from a .env file, similarly to node or docker.'
-
-    PSEdition         = @('Desk', 'Core')
 
     # Minimum version of the PowerShell engine required by this module
     # PowerShellVersion = ''


### PR DESCRIPTION
To fix a following error.

> Import-Module: The 'C:\Users\kazuki\Projects\poshdotenv\module\dotenv\dotenv.psd1' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ('ModuleToProcess', 'NestedModules', 'GUID', 'Author', 'CompanyName', 'Copyright', 'ModuleVersion', 'Description', 'PowerShellVersion', 'PowerShellHostName', 'PowerShellHostVersion', 'CLRVersion', 'DotNetFrameworkVersion', 'ProcessorArchitecture', 'RequiredModules', 'TypesToProcess', 'FormatsToProcess', 'ScriptsToProcess', 'PrivateData', 'RequiredAssemblies', 'ModuleList', 'FileList', 'FunctionsToExport', 'VariablesToExport', 'AliasesToExport', 'CmdletsToExport', 'DscResourcesToExport', 'CompatiblePSEditions', 'HelpInfoURI', 'RootModule', 'DefaultCommandPrefix'). Remove the members that are not valid ('PSEdition'), then try to import the module again.

https://docs.microsoft.com/en-us/powershell/scripting/gallery/concepts/module-psedition-support?view=powershell-7.1